### PR TITLE
Support Extended User Model

### DIFF
--- a/django_warrant/backend.py
+++ b/django_warrant/backend.py
@@ -29,8 +29,10 @@ class CognitoUser(Cognito):
         extra_attrs = {}
         for k, v in user_attrs.items():
             if k not in django_fields:
-                extra_attrs.update({k: user_attrs.pop(k, None)})
-        if getattr(settings, 'COGNITO_CREATE_UNKNOWN_USERS', True):
+                extra_attrs.update({k: user_attrs.get(k, None)})
+        for k in extra_attrs:
+            user_attrs.pop(k)
+        if getattr(settings, 'CREATE_UNKNOWN_USERS', True):
             user, created = CognitoUser.user_class.objects.update_or_create(
                 username=username,
                 defaults=user_attrs)

--- a/django_warrant/backend.py
+++ b/django_warrant/backend.py
@@ -8,6 +8,9 @@ from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth import get_user_model
 from django.utils.six import iteritems
 
+
+import magicattr
+
 from warrant import Cognito
 from .utils import cognito_to_dict
 
@@ -46,7 +49,8 @@ class CognitoUser(Cognito):
                     user = None
         if user:
             for k, v in extra_attrs.items():
-                setattr(user, k, v)
+                magicattr.set(user, k, v)
+            user.save()
         return user
 
 

--- a/django_warrant/views/subscriptions.py
+++ b/django_warrant/views/subscriptions.py
@@ -17,7 +17,8 @@ from django_warrant.forms import APIKeySubscriptionForm
 
 
 class GetCognitoUserMixin(object):
-    client = boto3.client('apigateway')
+    region = settings.COGNITO_USER_POOL_ID.split('_')[0]
+    client = boto3.client('apigateway', region_name=region)
 
     def get_user_object(self):
         cog_client = boto3.client('cognito-idp')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Django>=2.0
 django-braces>=1.11.0
 django-crispy-forms>=1.6.1
 django-extensions>=1.7.7
+magicattr==0.1.4
 warrant>=0.2.0


### PR DESCRIPTION
This PR is solving the issue of storing cognito related information in the django DB via an [extended user profile](https://docs.djangoproject.com/en/2.0/topics/auth/customizing/#extending-the-existing-user-model).

## Problem
With extending the user such a a profile model, the setattr doesn't work on nested objects. So if you set the COGNITO_ATTR_MAPPING with an entry, 'phone_number': 'profile.phone_number', the profile model won't update, thus the extra attributes lost.

## Solution
Use [magicattr](https://pypi.org/project/magicattr/) to set nested objects. Make sure to update the COGNITO_ATTR_MAPPING with a path to the nested object and attribute to update.

## Addition
* Fixed an issue where popping the user_attrs throws a modified dict exception during iteration.
* Added `COGNITO_REGION` to subscriptions since it dies due to lack of region if using EC2 instances with role profiles. (may need to break into separate PR?)